### PR TITLE
Fix I/O edge cases, remove dead code, and redundant code

### DIFF
--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -122,6 +122,7 @@ public class FileUtil {
                         .filter(file -> !file.getFileName().equals(oldPath.getFileName()))
                         .forEach(file -> {
                             try {
+                                file.toFile().setWritable(true);
                                 Files.deleteIfExists(file);
                                 System.err.println("Deleted old savefile: " + file);
                             } catch (IOException e) {
@@ -160,6 +161,7 @@ public class FileUtil {
                         .filter(file -> !file.getFileName().toString().equals("preferences.json"))
                         .forEach(file -> {
                             try {
+                                file.toFile().setWritable(true);
                                 Files.deleteIfExists(file);
                                 System.err.println("Deleted old savefile: " + file);
                             } catch (IOException e) {

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -78,23 +78,8 @@ public class SaveCommand extends Command {
             storage.saveUserPrefs(model.getUserPrefs());
 
             return new CommandResult(String.format(SUCCESS, pathToBeSaved), false, false, false);
-        } catch (AccessDeniedException e) {
-            throw new CommandException(String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException e) {
-            throw new CommandException(String.format(LogicManager.FILE_OPS_ERROR_FORMAT, e.getMessage()), e);
+            throw new CommandException(String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         }
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (object == this) {
-            return true;
-        }
-
-        if (!(object instanceof SaveCommand objectSaveCommand)) {
-            return false;
-        }
-
-        return fileName.equals(objectSaveCommand.fileName);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SaveCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;

--- a/src/main/java/seedu/address/logic/commands/SnapshotCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SnapshotCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
@@ -51,16 +50,6 @@ public class SnapshotCommand extends Command {
         requireNonNull(model);
 
         try {
-            Path snapshotDir = Paths.get(SNAPSHOTS_STRING);
-
-            if (!Files.exists(snapshotDir)) {
-                Files.createDirectories(snapshotDir);
-            }
-
-            if (!Files.isWritable(snapshotDir)) {
-                throw new CommandException("Can't write to snapshots folder. Check folder permissions.");
-            }
-
             String custom = currentDateTime.format(DateTimeFormatter.ofPattern("dMMMuuuu_HHmmss"));
             Path pathToBeSaved = Paths.get(SNAPSHOTS_STRING, custom + ".json");
             storage.makeSnapshot(model.getAddressBook(), pathToBeSaved);
@@ -71,18 +60,5 @@ public class SnapshotCommand extends Command {
         } catch (IOException e) {
             throw new CommandException(String.format(LogicManager.FILE_OPS_ERROR_FORMAT, e.getMessage()), e);
         }
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (object.hashCode() == this.hashCode()) {
-            return true;
-        }
-
-        if (!(object instanceof SnapshotCommand snapshotCommand)) {
-            return false;
-        }
-
-        return currentDateTime.equals(snapshotCommand.currentDateTime);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SnapshotCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SnapshotCommand.java
@@ -49,11 +49,11 @@ public class SnapshotCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        try {
-            String custom = currentDateTime.format(DateTimeFormatter.ofPattern("dMMMuuuu_HHmmss"));
-            Path pathToBeSaved = Paths.get(SNAPSHOTS_STRING, custom + ".json");
-            storage.makeSnapshot(model.getAddressBook(), pathToBeSaved);
+        String custom = currentDateTime.format(DateTimeFormatter.ofPattern("dMMMuuuu_HHmmss"));
+        Path pathToBeSaved = Paths.get(SNAPSHOTS_STRING, custom + ".json");
 
+        try {
+            storage.makeSnapshot(model.getAddressBook(), pathToBeSaved);
             return new CommandResult(String.format(SUCCESS, pathToBeSaved), false, false, false);
         } catch (AccessDeniedException e) {
             throw new CommandException(String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);

--- a/src/main/java/seedu/address/logic/commands/enumeration/SavingCommandTypes.java
+++ b/src/main/java/seedu/address/logic/commands/enumeration/SavingCommandTypes.java
@@ -10,7 +10,6 @@ public enum SavingCommandTypes {
     DELETE("delete"),
     EDIT("edit"),
     SETSTATUS("setstatus"),
-    SNAPSHOT("snapshot"),
     SWITCHCONTACT("switchContact"),
     TAG("tag"),
     UNTAG("untag");


### PR DESCRIPTION
After some tests, I noticed that there is no point in having `equals` in both Save and Snapshot feature. Therefore, they were removed. 
The input validation for `SaveCommand` is handled by `SaveCommandParser`. Therefore, `throw new CommandException(String.format(LogicManager.FILE_OPS_ERROR_FORMAT, e.getMessage()), e);` was removed.
Lastly, `snapshot` was removed from the `SavingCommandTypes` list as it clashes with the file permission exception thrown by `SaveCommand` (out-of-scope).

Resolves #235 