### PR TITLE
Make all commands case-insensitive for ease of use

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -56,7 +56,7 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)


### PR DESCRIPTION
Resolves #241

Made command case-insensitive. 
- e.g. `Add` will be parsed as `add`, `eDiT` will be parsed as `edit`

#240 Needs to be merged before switchcontact can be made insensitive