### PR TITLE
Error message for Email in Add Command is too long

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,11 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails must be in local-part@domain format:\n"
-            + "1. Local-part: Alphanumeric + special characters: " + SPECIAL_CHARACTERS + ", but cannot start/end "
+    public static final String MESSAGE_CONSTRAINTS = "Emails must be in Name@Domain format, for example: user@yahoo.com.\n"
+            + "1. Name: Alphanumeric + special characters: " + SPECIAL_CHARACTERS + ", but cannot start/end "
             + "with a special character.\n"
-            + "2. Domain: Domain Labels separated by periods. Must end with at least 2 character long domain label."
+            + "2. Domain: A domain is made up of domain labels, which are parts separated by periods."
+            +" Domain must end with at least 2 character long domain label."
             + " Labels must start/end with alphanumeric characters, allowing hyphens in between.";
+
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,11 +10,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails must be in Name@Domain format, for example: user@yahoo.com.\n"
+    public static final String MESSAGE_CONSTRAINTS = "Emails must be in Name@Domain format, for example:"
+            + "user@yahoo.com.\n"
             + "1. Name: Alphanumeric + special characters: " + SPECIAL_CHARACTERS + ", but cannot start/end "
             + "with a special character.\n"
             + "2. Domain: A domain is made up of domain labels, which are parts separated by periods."
-            +" Domain must end with at least 2 character long domain label."
+            + " Domain must end with at least 2 character long domain label."
             + " Labels must start/end with alphanumeric characters, allowing hyphens in between.";
 
     // alphanumeric and special characters

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -11,7 +11,7 @@ public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails must be in Name@Domain format, for example:"
-            + "user@yahoo.com.\n"
+            + " user@yahoo.com.\n"
             + "1. Name: Alphanumeric + special characters: " + SPECIAL_CHARACTERS + ", but cannot start/end "
             + "with a special character.\n"
             + "2. Domain: A domain is made up of domain labels, which are parts separated by periods."

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -10,17 +10,11 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
-            + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
-            + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+    public static final String MESSAGE_CONSTRAINTS = "Emails must be in local-part@domain format:\n"
+            + "1. Local-part: Alphanumeric + special characters: " + SPECIAL_CHARACTERS + ", but cannot start/end "
+            + "with a special character.\n"
+            + "2. Domain: Domain Labels separated by periods. Must end with at least 2 character long domain label."
+            + " Labels must start/end with alphanumeric characters, allowing hyphens in between.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"


### PR DESCRIPTION
Resolves #244

Reduced the length of the constraint message when incorrect email format is entered by user. 

![image](https://github.com/user-attachments/assets/1072b550-05f5-4a6d-95e4-1510896af1ea)
