### PR TITLE
Reorder User Guide Sections for "Editing Data File"

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -227,6 +227,19 @@ Examples:
 
 ![save with parameter](images/save_with_param.png)
 
+#### Editing the data file
+
+ArtHive data are saved automatically as a JSON file `[JAR file location]/data/[filename].json`. Advanced users are welcome to update data directly by editing that data file.
+
+<div markdown="span" class="alert alert-primary">:exclamation: **Note:**
+[filename] refers to the saved file name that is specified in `preferences.json`
+</div>
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+If your changes to the data file makes its format invalid, ArtHive will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
+Furthermore, certain edits can cause ArtHive to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+</div>
+
 ### Creating snapshot of data: `snapshot`
 
 Creates snapshot of the existing data in the `snapshots` directory with a datetime stamp ("dMMMuuuu_HHmmss").
@@ -256,19 +269,6 @@ Examples:
 
 ![switch contact to email](images/switchContactJohn.png)
 
-
-#### Editing the data file
-
-ArtHive data are saved automatically as a JSON file `[JAR file location]/data/[filename].json`. Advanced users are welcome to update data directly by editing that data file.
-
-<div markdown="span" class="alert alert-primary">:exclamation: **Note:**
-[filename] refers to the saved file name that is specified in `preferences.json`
-</div>
-
-<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-If your changes to the data file makes its format invalid, ArtHive will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
-Furthermore, certain edits can cause ArtHive to behave in unexpected ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
-</div>
 
 ### Clearing all entries : `clear`
 
@@ -312,6 +312,6 @@ Action | Format, Examples
 **UnTag**   | `untag p/PHONE (t/TAG \| project/PROJECT) [t/TAG]…​ [project/PROJECT]…​`<br> e.g., `tag p/91234567 t/bestie project/project-x`    
 **Save** | `save [FILENAME]` <br> e.g., `save newfile`                                                                                       
 **Snapshot** | `snapshot`                                                                                                                        
-**Switch Preferred Contact Method** | `switchContact p/PHONE_NUMBER` <br> e.g, `switchContact p/91234567`                                                               
+**Switch Preferred Contact Method** | `switchcontact p/PHONE_NUMBER` <br> e.g, `switchcontact p/91234567`                                                               
 **Clear** | `clear`                                                                                                                           
 **Exit** | `exit`                                                                                                                            

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -252,11 +252,11 @@ Examples:
 
 ![snapshot](images/snapshot.png)
 
-### Switching preferred contact : `switchContact`
+### Switching preferred contact : `switchcontact`
 
 Switch preferred contact. 
 
-Format: `switchContact p/PHONE`
+Format: `switchcontact p/PHONE`
 
 * If the current preferred contact method is email, it will switch to phone.
 * If the current preferred contact method is phone, it will switch to email, provided the contact contains an email.
@@ -265,7 +265,7 @@ Format: `switchContact p/PHONE`
 
 Examples:
 
-* `switchContact p/91234567` Switches the preferred contact method for the contact with phone number 91234567.
+* `switchcontact p/91234567` Switches the preferred contact method for the contact with phone number 91234567.
 
 ![switch contact to email](images/switchContactJohn.png)
 


### PR DESCRIPTION
Moved "Editing Data File" subsection to be directly below the "Save" section.

Modified `switchcontact` to reflect new command wording (no capital C)

Resolve #245 