### PR TITLE
Use of non-alphanumeric characters in Name for Add command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/enumeration/PrefixEnum.java
+++ b/src/main/java/seedu/address/logic/commands/enumeration/PrefixEnum.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.commands.enumeration;
+
+/**
+ * Enumeration representing different prefixes used in command parsing.
+ */
+public enum PrefixEnum {
+    PREFIX_NAME("n/"),
+    PREFIX_PHONE("p/"),
+    PREFIX_EMAIL("e/"),
+    PREFIX_TAG("t/"),
+    PREFIX_PROJECT("project/"),
+    PREFIX_DEADLINE("d/"),
+    PREFIX_PAYMENT("pay/"),
+    PREFIX_PROGRESS("prog/");
+    private final String prefix;
+    PrefixEnum(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+    /**
+     * Checks if a given string contains any of the defined prefixes.
+     *
+     * @param name The string to check for the presence of any prefix.
+     * @return {@code true} if the string contains a prefix, {@code false} otherwise.
+     */
+    public static boolean containsPrefix(String name) {
+        for (PrefixEnum preix : PrefixEnum.values()) {
+            if (name.contains(preix.getPrefix())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/enumeration/PrefixEnum.java
+++ b/src/main/java/seedu/address/logic/commands/enumeration/PrefixEnum.java
@@ -8,8 +8,8 @@ public enum PrefixEnum {
     PREFIX_PHONE("p/"),
     PREFIX_EMAIL("e/"),
     PREFIX_TAG("t/"),
-    PREFIX_PROJECT("project/"),
-    PREFIX_DEADLINE("d/"),
+    PREFIX_PROJECT("proj/"),
+    PREFIX_DEADLINE("by/"),
     PREFIX_PAYMENT("pay/"),
     PREFIX_PROGRESS("prog/");
     private final String prefix;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -49,7 +49,9 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            String errorMessage = Name.invaildNameCheck(trimmedName).get();
+
+            throw new ParseException(errorMessage);
         }
         return new Name(trimmedName);
     }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -26,7 +26,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.\\/ ]*";
+    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.,\\/ ]*";
     private static final Logger logger = LogsCenter.getLogger(JsonSnapshotStorage.class);
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,10 +17,10 @@ import seedu.address.storage.JsonSnapshotStorage;
 public class Name {
 
     public static final String INVALID_NAME_CHARACTERS_MESSAGE = "Name contains invalid characters. Only letters,"
-            + " numbers, spaces, '-', '_', '.', and '/' are allowed.";
-    public static final String NAME_LENGTH_ERROR = "Name must not exceed 40 characters.";
-    public static final String EMPTY_NAME_MSG = "Name field cannot be empty.";
-    public static final String NAME_CONTAINS_PREFIX = "Name contains command prefix.";
+            + " numbers, spaces, '-', '_', '.', ',' and '/' are allowed.";
+    public static final String MESSAGE_NAME_LENGTH_ERROR = "Name must not exceed 40 characters.";
+    public static final String MESSAGE_EMPTY_NAME_MSG = "Name field cannot be empty.";
+    public static final String MESSAGE_NAME_CONTAINS_PREFIX = "Name contains command prefix.";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -48,11 +48,11 @@ public class Name {
 
         //Check if there is blank
         if (test.isBlank()) {
-            return Optional.of(EMPTY_NAME_MSG);
+            return Optional.of(MESSAGE_EMPTY_NAME_MSG);
         }
 
         if (PrefixEnum.containsPrefix(test)) {
-            return Optional.of(NAME_CONTAINS_PREFIX);
+            return Optional.of(MESSAGE_NAME_CONTAINS_PREFIX);
         }
 
         logger.fine("Remaining String length: " + test.length());
@@ -61,7 +61,7 @@ public class Name {
         if (!test.matches(VALIDATION_REGEX)) {
             return Optional.of(INVALID_NAME_CHARACTERS_MESSAGE);
         } else if (test.length() > 40) {
-            return Optional.of(NAME_LENGTH_ERROR);
+            return Optional.of(MESSAGE_NAME_LENGTH_ERROR );
         }
 
         return Optional.empty();

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.][-a-zA-Z0-9_.\\/ ]{0,40}$";
+    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.][-a-zA-Z0-9_.\\/ ]{0,39}$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -20,7 +20,7 @@ public class Name {
             + " numbers, spaces, '-', '_', '.', and '/' are allowed.";
     public static final String NAME_LENGTH_ERROR = "Name must not exceed 40 characters.";
     public static final String EMPTY_NAME_MSG = "Name field cannot be empty.";
-    public static final String NAME_CONTAINS_PREFIX = "Name cannot contain prefixes.";
+    public static final String NAME_CONTAINS_PREFIX = "Name contains command prefix.";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[\\p{Alnum}][\\p{Alnum} ]{0,39}$";
+    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.][-a-zA-Z0-9_.\\/ ]{0,40}$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -55,7 +55,7 @@ public class Name {
             return Optional.of(MESSAGE_NAME_CONTAINS_PREFIX);
         }
 
-        logger.fine("Remaining String length: " + test.length());
+        logger.fine("Remaining String length: " + test.length() );
         logger.fine("Name input: " + test);
 
         if (!test.matches(VALIDATION_REGEX)) {

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.enumeration.PrefixEnum;
 import seedu.address.storage.JsonSnapshotStorage;
 
 /**
@@ -18,7 +19,8 @@ public class Name {
     public static final String INVALID_NAME_CHARACTERS_MESSAGE = "Name contains invalid characters. Only letters,"
             + " numbers, spaces, '-', '_', '.', and '/' are allowed.";
     public static final String NAME_LENGTH_ERROR = "Name must not exceed 40 characters.";
-    public static final String EMPTY_NAME_MSG = "Name field cannot be empty";
+    public static final String EMPTY_NAME_MSG = "Name field cannot be empty.";
+    public static final String NAME_CONTAINS_PREFIX = "Name cannot contain prefixes.";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -44,8 +46,13 @@ public class Name {
      */
     public static Optional<String> invaildNameCheck(String test) {
 
+        //Check if there is blank
         if (test.isBlank()) {
             return Optional.of(EMPTY_NAME_MSG);
+        }
+
+        if (PrefixEnum.containsPrefix(test)) {
+            return Optional.of(NAME_CONTAINS_PREFIX);
         }
 
         logger.fine("Remaining String length: " + test.length());

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -3,22 +3,29 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.storage.JsonSnapshotStorage;
+
 /**
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters, spaces, a max of 40 characters, and it should not be"
-                    + " blank";
+    public static final String INVALID_NAME_CHARACTERS_MESSAGE = "Name contains invalid characters. Only letters,"
+            + " numbers, spaces, '-', '_', '.', and '/' are allowed.";
+    public static final String NAME_LENGTH_ERROR = "Name must not exceed 40 characters.";
+    public static final String EMPTY_NAME_MSG = "Name field cannot be empty";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.][-a-zA-Z0-9_.\\/ ]{0,39}$";
-
+    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.\\/ ]*";
+    private static final Logger logger = LogsCenter.getLogger(JsonSnapshotStorage.class);
     public final String fullName;
 
     /**
@@ -28,15 +35,43 @@ public class Name {
      */
     public Name(String name) {
         requireNonNull(name);
-        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidName(name));
         fullName = name;
     }
 
     /**
      * Returns true if a given string is a valid name.
      */
+    public static Optional<String> invaildNameCheck(String test) {
+
+        if (test.isBlank()) {
+            return Optional.of(EMPTY_NAME_MSG);
+        }
+
+        logger.fine("Remaining String length: " + test.length());
+        logger.fine("Name input: " + test);
+
+        if (!test.matches(VALIDATION_REGEX)) {
+            return Optional.of(INVALID_NAME_CHARACTERS_MESSAGE);
+        } else if (test.length() > 40) {
+            return Optional.of(NAME_LENGTH_ERROR);
+        }
+
+        return Optional.empty();
+
+    }
+
+    /**
+     * Checks whether a given name string is valid
+     *
+     * @param test The name string to validate
+     * @return {@code true} if the name is valid, {@code false} otherwise.
+     */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        Optional<String> errorMessage = invaildNameCheck(test);
+
+        //Checks if name contains invalid characters
+        return errorMessage.isEmpty();
     }
 
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ import seedu.address.storage.JsonSnapshotStorage;
 public class Name {
 
     public static final String INVALID_NAME_CHARACTERS_MESSAGE = "Name contains invalid characters. Only letters,"
-            + " numbers, spaces, '-', '_', '.', ',' and '/' are allowed.";
+            + " numbers, spaces, '-', '_', '.', ',', apostrophe (') and '/' are allowed.";
     public static final String MESSAGE_NAME_LENGTH_ERROR = "Name must not exceed 40 characters.";
     public static final String MESSAGE_EMPTY_NAME_MSG = "Name field cannot be empty.";
     public static final String MESSAGE_NAME_CONTAINS_PREFIX = "Name contains command prefix.";
@@ -26,7 +26,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_.,\\/ ]*";
+    public static final String VALIDATION_REGEX = "^[-a-zA-Z0-9_'.,\\/ ]*";
     private static final Logger logger = LogsCenter.getLogger(JsonSnapshotStorage.class);
     public final String fullName;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -102,7 +102,7 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
         if (!Name.isValidName(name)) {
-            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Name.INVALID_NAME_CHARACTERS_MESSAGE);
         }
         final Name modelName = new Name(name);
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -143,7 +143,7 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.INVALID_NAME_CHARACTERS_MESSAGE);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB
@@ -159,7 +159,7 @@ public class AddCommandParserTest {
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.INVALID_NAME_CHARACTERS_MESSAGE);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -71,7 +71,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.INVALID_NAME_CHARACTERS_MESSAGE); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
 
@@ -80,7 +80,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.INVALID_NAME_CHARACTERS_MESSAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -34,8 +34,8 @@ public class NameTest {
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
         assertFalse(Name.isValidName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // more than 40 chars
         assertFalse(Name.isValidName("John@Doe")); // with invalid special characters @
-        assertFalse(Name.isValidName("John Doe!"));  // with invalid special characters !
-        assertFalse(Name.isValidName("John Doe\\"));  // with invalid special characters \\
+        assertFalse(Name.isValidName("John Doe!")); // with invalid special characters !
+        assertFalse(Name.isValidName("John Doe\\")); // with invalid special characters \\
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -61,6 +61,7 @@ public class NameTest {
         assertTrue(Name.isValidName("Oneida / ka")); // with slash and dot
         assertTrue(Name.isValidName("Tom s/o Tommy")); // with slash and dot
         assertTrue(Name.isValidName("Tom, Tea Tommy")); // with comma
+        assertTrue(Name.isValidName("O'neil Tommy")); // with apostrophe
         assertTrue(Name.isValidName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // 40 characters
 
     }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -104,7 +104,7 @@ public class NameTest {
         String nameTooLong = "a".repeat(41); // 41 characters, should be invalid
         Optional<String> errorMessage = Name.invaildNameCheck(nameTooLong);
         assertTrue(errorMessage.isPresent());
-        assertEquals(Name.NAME_LENGTH_ERROR, errorMessage.get());
+        assertEquals(Name.MESSAGE_NAME_LENGTH_ERROR, errorMessage.get());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class NameTest {
         String emptyName = ""; // Empty name
         Optional<String> errorMessage = Name.invaildNameCheck(emptyName);
         assertTrue(errorMessage.isPresent());
-        assertEquals(Name.EMPTY_NAME_MSG, errorMessage.get());
+        assertEquals(Name.MESSAGE_EMPTY_NAME_MSG, errorMessage.get());
     }
 
     @Test
@@ -120,6 +120,6 @@ public class NameTest {
         String emptyName = " "; // Empty name
         Optional<String> errorMessage = Name.invaildNameCheck(emptyName);
         assertTrue(errorMessage.isPresent());
-        assertEquals(Name.EMPTY_NAME_MSG, errorMessage.get());
+        assertEquals(Name.MESSAGE_EMPTY_NAME_MSG, errorMessage.get());
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -1,8 +1,11 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,14 +33,21 @@ public class NameTest {
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
         assertFalse(Name.isValidName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // more than 40 chars
-
+        assertFalse(Name.isValidName("John@Doe")); // with invalid special characters @
+        assertFalse(Name.isValidName("John Doe!"));  // with invalid special characters !
+        assertFalse(Name.isValidName("John Doe\\"));  // with invalid special characters \\
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("John Doe.")); // with doe
+        assertTrue(Name.isValidName("John/Doe")); // with slash
+        assertTrue(Name.isValidName("John_Doe")); // with underscore
+        assertTrue(Name.isValidName("Dr. /Prof John")); // with slash and dot
+        assertTrue(Name.isValidName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // 40 characters
+        assertTrue(Name.isValidName("p/91919191")); // with known delimiter
     }
 
     @Test
@@ -64,5 +74,37 @@ public class NameTest {
 
         // upper/lower case are not the same
         assertFalse(name.equals(new Name("valid name")));
+    }
+
+    @Test
+    public void invalidName_characters_invalid() {
+        String invalidName = "John@Doe"; // Invalid because of '@'
+        Optional<String> errorMessage = Name.invaildNameCheck(invalidName);
+        assertTrue(errorMessage.isPresent());
+        assertEquals(Name.INVALID_NAME_CHARACTERS_MESSAGE, errorMessage.get());
+    }
+
+    @Test
+    public void nameTooLong_invalid() {
+        String nameTooLong = "a".repeat(41); // 41 characters, should be invalid
+        Optional<String> errorMessage = Name.invaildNameCheck(nameTooLong);
+        assertTrue(errorMessage.isPresent());
+        assertEquals(Name.NAME_LENGTH_ERROR, errorMessage.get());
+    }
+
+    @Test
+    public void emptyName_invalid() {
+        String emptyName = ""; // Empty name
+        Optional<String> errorMessage = Name.invaildNameCheck(emptyName);
+        assertTrue(errorMessage.isPresent());
+        assertEquals(Name.EMPTY_NAME_MSG, errorMessage.get());
+    }
+
+    @Test
+    public void spaceName_invalid() {
+        String emptyName = " "; // Empty name
+        Optional<String> errorMessage = Name.invaildNameCheck(emptyName);
+        assertTrue(errorMessage.isPresent());
+        assertEquals(Name.EMPTY_NAME_MSG, errorMessage.get());
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -32,7 +32,6 @@ public class NameTest {
         assertFalse(Name.isValidName("abcby/991")); // with known delimiter
         assertFalse(Name.isValidName("abcpay/991")); // with known delimiter
         assertFalse(Name.isValidName("abcpaprog/991")); // with known delimiter
-
     }
 
     @Test
@@ -61,6 +60,7 @@ public class NameTest {
         assertTrue(Name.isValidName("Dr. /Prof John")); // with slash and dot
         assertTrue(Name.isValidName("Oneida / ka")); // with slash and dot
         assertTrue(Name.isValidName("Tom s/o Tommy")); // with slash and dot
+        assertTrue(Name.isValidName("Tom, Tea Tommy")); // with comma
         assertTrue(Name.isValidName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // 40 characters
 
     }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -28,8 +28,8 @@ public class NameTest {
         assertFalse(Name.isValidName("abcp/991")); // with known delimiter
         assertFalse(Name.isValidName("abce/991")); // with known delimiter
         assertFalse(Name.isValidName("abct/991")); // with known delimiter
-        assertFalse(Name.isValidName("abcproject/991")); // with known delimiter
-        assertFalse(Name.isValidName("abcd/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcproj/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcby/991")); // with known delimiter
         assertFalse(Name.isValidName("abcpay/991")); // with known delimiter
         assertFalse(Name.isValidName("abcpaprog/991")); // with known delimiter
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -23,6 +23,19 @@ public class NameTest {
     }
 
     @Test
+    public void nameContainsPrefix() {
+        assertFalse(Name.isValidName("abcn/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcp/991")); // with known delimiter
+        assertFalse(Name.isValidName("abce/991")); // with known delimiter
+        assertFalse(Name.isValidName("abct/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcproject/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcd/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcpay/991")); // with known delimiter
+        assertFalse(Name.isValidName("abcpaprog/991")); // with known delimiter
+
+    }
+
+    @Test
     public void isValidName() {
         // null name
         assertThrows(NullPointerException.class, () -> Name.isValidName(null));
@@ -43,11 +56,13 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("John Doe.")); // with doe
-        assertTrue(Name.isValidName("John/Doe")); // with slash
+        assertTrue(Name.isValidName("Joh/Doe")); // with slash
         assertTrue(Name.isValidName("John_Doe")); // with underscore
         assertTrue(Name.isValidName("Dr. /Prof John")); // with slash and dot
+        assertTrue(Name.isValidName("Oneida / ka")); // with slash and dot
+        assertTrue(Name.isValidName("Tom s/o Tommy")); // with slash and dot
         assertTrue(Name.isValidName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // 40 characters
-        assertTrue(Name.isValidName("p/91919191")); // with known delimiter
+
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -44,7 +44,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_TAGS,
                         VALID_PROJECTS, VALID_CONTACT_METHOD);
-        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Name.INVALID_NAME_CHARACTERS_MESSAGE;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 


### PR DESCRIPTION
The regex for validating a person's name has been updated to allow additional special characters 
- Dash (-)
- Dot (.)
- Slash (/) -  Slash will not be allowed as the first character.
- Underscore (_)



This resolves #239, resolves #242 and resolves #254